### PR TITLE
Rely on fromEvent via Rx.Observable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,21 +29,9 @@ function createObserver(jmpSocket) {
 }
 
 function createObservable(jmpSocket) {
-  return Observable.create(observer => {
-    jmpSocket.on('message', message => {
-      observer.onNext(message);
-    });
-
-    jmpSocket.on('error', err => {
-      observer.onError(err);
-    });
-
-    return () => {
-      jmpSocket.close();
-    };
-  })
-  .publish()
-  .refCount();
+  return Observable.fromEvent(jmpSocket, 'message')
+                   .publish()
+                   .refCount();
 }
 
 function createSubject(jmpSocket) {


### PR DESCRIPTION
Since the only events we care about are `message` and `error`, `Rx.Observable.fromEvent` handles all our cases and will free up listeners directly for us. Less code is better code.
