### PR TITLE
Full cleanup

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -37,7 +37,7 @@ global.uuid = uuid;
 
   console.log('var payload = ');
   console.log(message);
-  console.log('\n      ' + chalk.white('enchan.io.subscribe(console.log)'));
+  console.log('\n      ' + chalk.white('enchan.iopub.subscribe(console.log)'));
   console.log('\n      ' + chalk.white('enchan.shell.subscribe(console.log)'));
   console.log('\n      ' + chalk.white('enchan.shell.send(payload)'));
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ function createObserver(jmpSocket) {
     // We don't expect to send errors to the kernel
     console.error(err);
   }, () => {
+    // tear it down, tear it *all* down
+    jmpSocket.removeAllListeners();
     jmpSocket.close();
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ function createSubject(jmpSocket) {
   const subj = Subject.create(createObserver(jmpSocket),
                               createObservable(jmpSocket));
   subj.send = subj.onNext; // Adapt naming to fit our parlance
+  subj.close = subj.onCompleted;
   return subj;
 }
 


### PR DESCRIPTION
Ensure all the listeners are removed when `onCompleted` is called. Additionally, alias `onCompleted` to `close`.

In the future, we'll want to create a subclass of Subject that has `close` and `send` defined (so we're not declaring it on each instance). It may be that there's [little performance penalty for this though since we only do it once](http://www.html5rocks.com/en/tutorials/speed/v8/).
