### PR TITLE
Create a channel creation helper, comment all over

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Until we make changes, you'll need to have at least one subscription before you 
 ```
 
 ```javascript
-> channels.shell.send(payload)
+> shell.send(payload)
 > Message {
   header:
    { username: 'rgbkrk',

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ import {
  * @return {Rx.Subject} subject for sending and receiving messages on the shell
  *                      channel
  */
-function createChannelSubject(channel, identity, config) {
+export function createChannelSubject(channel, identity, config) {
   return createSubject(createSocket(channel, identity, config));
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,26 @@ import {
 } from './subjection';
 
 /**
+ * createChannelSubject creates a subject for sending and receiving messages on
+ * the given channel
+ * @param  {string} channel                 iopub || shell || control || stdin
+ * @param  {string} identity                UUID
+ * @param  {Object} config                  Jupyter connection information
+ * @param  {string} config.ip               IP address of the kernel
+ * @param  {string} config.transport        Transport, e.g. TCP
+ * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
+ * @param  {number} config.shell_port       Port for shell channel
+ * @return {Rx.Subject} subject for sending and receiving messages on the shell
+ *                      channel
+ */
+function createChannelSubject(channel, identity, config) {
+  return createSubject(createSocket(channel, identity, config));
+}
+
+/**
  * createShellSubject creates a subject for sending and receiving messages on a
  * kernel's shell channel
- * @param  {string} identity UUID
+ * @param  {string} identity                UUID
  * @param  {Object} config                  Jupyter connection information
  * @param  {string} config.ip               IP address of the kernel
  * @param  {string} config.transport        Transport, e.g. TCP
@@ -23,13 +40,13 @@ import {
  *                      channel
  */
 export function createShellSubject(identity, config) {
-  return createSubject(createSocket(SHELL, identity, config));
+  return createChannelSubject(SHELL, identity, config);
 }
 
 /**
  * createControlSubject creates a subject for sending and receiving on a
  * kernel's control channel
- * @param  {string} identity UUID
+ * @param  {string} identity                UUID
  * @param  {Object} config                  Jupyter connection information
  * @param  {string} config.ip               IP address of the kernel
  * @param  {string} config.transport        Transport, e.g. TCP
@@ -39,13 +56,13 @@ export function createShellSubject(identity, config) {
  *                      channel
  */
 export function createControlSubject(identity, config) {
-  return createSubject(createSocket(CONTROL, identity, config));
+  return createChannelSubject(CONTROL, identity, config);
 }
 
 /**
  * createStdinSubject creates a subject for sending and receiving messages on a
  * kernel's stdin channel
- * @param  {string} identity UUID
+ * @param  {string} identity                UUID
  * @param  {Object} config                  Jupyter connection information
  * @param  {string} config.ip               IP address of the kernel
  * @param  {string} config.transport        Transport, e.g. TCP
@@ -55,13 +72,13 @@ export function createControlSubject(identity, config) {
  *                      channel
  */
 export function createStdinSubject(identity, config) {
-  return createSubject(createSocket(STDIN, identity, config));
+  return createChannelSubject(STDIN, identity, config);
 }
 
 /**
  * createIOPubSubject creates a shell subject for receiving messages on a
  * kernel's iopub channel
- * @param  {string} identity UUID
+ * @param  {string} identity                UUID
  * @param  {Object} config                  Jupyter connection information
  * @param  {string} config.ip               IP address of the kernel
  * @param  {string} config.transport        Transport, e.g. TCP
@@ -73,6 +90,7 @@ export function createStdinSubject(identity, config) {
  */
 export function createIOPubSubject(identity, config, subscription = '') {
   const ioPubSocket = createSocket(IOPUB, identity, config);
+  // ZMQ PUB/SUB subscription (not an Rx subscription)
   ioPubSocket.subscribe(subscription);
   return createSubject(ioPubSocket);
 }

--- a/test/channeling_spec.js
+++ b/test/channeling_spec.js
@@ -1,0 +1,47 @@
+/* eslint camelcase: 0 */ // <-- Per Jupyter message spec
+import * as uuid from 'uuid';
+
+import { expect } from 'chai';
+
+import {
+  createChannelSubject,
+  createIOPubSubject,
+} from '../src';
+
+import {
+  AnonymousSubject,
+} from 'rx';
+
+describe('createChannelSubject', () => {
+  it('creates a subject for the channel', () => {
+    const config = {
+      signature_scheme: 'hmac-sha256',
+      key: '5ca1ab1e-c0da-aced-cafe-c0ffeefacade',
+      ip: '127.0.0.1',
+      transport: 'tcp',
+      iopub_port: 19009,
+    };
+    const s = createChannelSubject('iopub', uuid.v4(), config);
+    expect(s).to.be.instanceof(AnonymousSubject);
+    expect(s.onNext).to.be.a('function');
+    expect(s.send).to.be.a('function');
+    expect(s.onCompleted).to.be.a('function');
+    expect(s.close).to.be.a('function');
+    expect(s.subscribe).to.be.a('function');
+    s.close();
+  });
+});
+
+describe('createIOPubSubject', () => {
+  it('creates a subject with the default iopub subscription', () => {
+    const config = {
+      signature_scheme: 'hmac-sha256',
+      key: '5ca1ab1e-c0da-aced-cafe-c0ffeefacade',
+      ip: '127.0.0.1',
+      transport: 'tcp',
+      iopub_port: 19011,
+    };
+    const s = createIOPubSubject(uuid.v4(), config);
+    s.close();
+  });
+});

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -8,7 +8,7 @@ import {
 } from '..';
 
 // Solely testing the exported interface on the built ES5 JavaScript
-describe('index', () => {
+describe('the built version of enchannel-zmq-backend', () => {
   it('exports create helpers for control, stdin, iopub, and shell', () => {
     expect(createControlSubject).to.not.be.undefined;
     expect(createStdinSubject).to.not.be.undefined;

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -185,5 +185,6 @@ describe('createSocket', () => {
     expect(socket).to.not.be.null;
     expect(socket.identity).to.equal(identity);
     expect(socket.type).to.equal(constants.ZMQType.frontend.iopub);
+    socket.close();
   });
 });


### PR DESCRIPTION
Reduce `createSubject(createSocket(...))` to a helper function. Increase comment coverage.
