### PR TITLE
Rxjs five

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
     "jmp": "^0.2.4",
-    "rx": "^4.0.7",
+    "@reactivex/rxjs": "^5.0.0-beta.1",
     "uuid": "^2.0.1"
   },
   "babel": {

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -15,11 +15,13 @@ const runtimeDir = require('jupyter-paths').runtimeDir();
 
 fsp.readdir(runtimeDir)
    .then(data => {
-	  const kernels = data.filter(x => /kernel.+\.json/.test(x))
-	  if(kernels.length <= 0) throw new Error('You need a running Jupyter session');
-    console.log('Using the first kernel!');
-    return path.join(runtimeDir, kernels[0]);
-	})
+     const kernels = data.filter(x => (/kernel.+\.json/).test(x));
+     if(kernels.length <= 0) {
+       throw new Error('You need a running Jupyter session');
+     }
+     console.log('Using the first kernel!');
+     return path.join(runtimeDir, kernels[0]);
+   })
   .then(runtimePath => {
     return fsp.readFile(runtimePath);
   })
@@ -27,7 +29,7 @@ fsp.readdir(runtimeDir)
     return JSON.parse(contents);
   })
   .then(kernelConfig => {
-  	const shell = createShellSubject(identity, kernelConfig);
+    const shell = createShellSubject(identity, kernelConfig);
     const iopub = createIOPubSubject(identity, kernelConfig);
     global.shell = shell;
     global.iopub = iopub;
@@ -48,14 +50,13 @@ fsp.readdir(runtimeDir)
         allow_stdin: false,
       },
     };
-  
-    console.log(chalk.green('\nHINT: ') + chalk.white('iopub.subscribe(console.log, console.error)'))
-    console.log(chalk.green('\nHINT: ') + chalk.white('shell.subscribe(console.log, console.error)'))
-    console.log(chalk.green('\nHINT: ') + chalk.white('shell.send(message)'))
 
-	  require('repl').start('> ');
+    console.log(chalk.green('\nHINT: ') + chalk.white('iopub.subscribe(console.log, console.error)'));
+    console.log(chalk.green('\nHINT: ') + chalk.white('shell.subscribe(console.log, console.error)'));
+    console.log(chalk.green('\nHINT: ') + chalk.white('shell.send(message)'));
+
+    require('repl').start('> ');
   })
   .catch(err => {
     console.error(err);
-  })
-
+  });

--- a/src/subjection.js
+++ b/src/subjection.js
@@ -1,4 +1,4 @@
-import { Observer, Observable, Subject } from 'rx';
+import { Subscriber, Observable, Subject } from '@reactivex/rxjs';
 import * as jmp from 'jmp';
 
 import {
@@ -44,11 +44,11 @@ export function formConnectionString(config, channel) {
  * A RxJS wrapper around jmp sockets, that takes care of sending messages and
  * cleans up after itself
  * @param {jmp.Socket} socket the jmp/zmq socket connection to a kernel channel
- * @return {Rx.Observer} an observer that allows sending messages onNext and
- *                       closes the underlying socket onCompleted
+ * @return {Rx.Subscriber} a subscriber that allows sending messages on next()
+ *                         and closes the underlying socket on complete()
  */
-export function createObserver(socket) {
-  return Observer.create(messageObject => {
+export function createSubscriber(socket) {
+  return Subscriber.create(messageObject => {
     socket.send(new jmp.Message(messageObject));
   }, err => {
     // We don't expect to send errors to the kernel
@@ -87,10 +87,8 @@ export function createObservable(socket) {
  * @return {Rx.Subject} subject for sending and receiving messages to kernels
  */
 export function createSubject(socket) {
-  const subj = Subject.create(createObserver(socket),
-                              createObservable(socket));
-  subj.send = subj.onNext;       // Adapt naming to fit our parlance
-  subj.close = subj.onCompleted;
+  const subj = Subject.create(createObservable(socket),
+                              createSubscriber(socket));
   return subj;
 }
 

--- a/test/channeling_spec.js
+++ b/test/channeling_spec.js
@@ -8,10 +8,6 @@ import {
   createIOPubSubject,
 } from '../src';
 
-import {
-  AnonymousSubject,
-} from 'rx';
-
 describe('createChannelSubject', () => {
   it('creates a subject for the channel', () => {
     const config = {
@@ -22,13 +18,10 @@ describe('createChannelSubject', () => {
       iopub_port: 19009,
     };
     const s = createChannelSubject('iopub', uuid.v4(), config);
-    expect(s).to.be.instanceof(AnonymousSubject);
-    expect(s.onNext).to.be.a('function');
-    expect(s.send).to.be.a('function');
-    expect(s.onCompleted).to.be.a('function');
-    expect(s.close).to.be.a('function');
+    expect(s.next).to.be.a('function');
+    expect(s.complete).to.be.a('function');
     expect(s.subscribe).to.be.a('function');
-    s.close();
+    s.complete();
   });
 });
 
@@ -42,6 +35,6 @@ describe('createIOPubSubject', () => {
       iopub_port: 19011,
     };
     const s = createIOPubSubject(uuid.v4(), config);
-    s.close();
+    s.complete();
   });
 });

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -16,7 +16,7 @@ import * as jmp from 'jmp';
 
 import {
   deepFreeze,
-  createObserver,
+  createSubscriber,
   createObservable,
   createSubject,
   createSocket,
@@ -41,28 +41,28 @@ describe('deepFreeze', () => {
   });
 });
 
-describe('createObserver', () => {
-  it('creates an observer from a socket', () => {
+describe('createSubscriber', () => {
+  it('creates a subscriber from a socket', () => {
     const hokeySocket = {
       send: sinon.spy(),
       removeAllListeners: sinon.spy(),
       close: sinon.spy(),
     };
 
-    const ob = createObserver(hokeySocket);
+    const ob = createSubscriber(hokeySocket);
     const message = { content: { x: 2 } };
-    ob.onNext(message);
+    ob.next(message);
     expect(hokeySocket.send).to.have.been.calledWith(new jmp.Message(message));
   });
-  it('removes all listeners and closes the socket onCompleted', () => {
+  it('removes all listeners and closes the socket on complete()', () => {
     const hokeySocket = {
       send: sinon.spy(),
       removeAllListeners: sinon.spy(),
       close: sinon.spy(),
     };
 
-    const ob = createObserver(hokeySocket);
-    ob.onCompleted();
+    const ob = createSubscriber(hokeySocket);
+    ob.complete();
     expect(hokeySocket.removeAllListeners).to.have.been.calledWith();
     expect(hokeySocket.close).to.have.been.calledWith();
   });
@@ -73,14 +73,14 @@ describe('createObserver', () => {
       close: sinon.spy(),
     };
 
-    const ob = createObserver(hokeySocket);
-    ob.onCompleted();
+    const ob = createSubscriber(hokeySocket);
+    ob.complete();
     expect(hokeySocket.removeAllListeners).to.have.been.calledWith();
     expect(hokeySocket.close).to.have.been.calledWith();
 
     hokeySocket.removeAllListeners = sinon.spy();
     hokeySocket.close = sinon.spy();
-    ob.onCompleted();
+    ob.complete();
     expect(hokeySocket.removeAllListeners).to.not.have.been.calledWith();
     expect(hokeySocket.close).to.not.have.been.calledWith();
   });
@@ -148,7 +148,7 @@ describe('createSubject', () => {
           success: true,
         },
       });
-      s.close();
+      s.complete();
       expect(hokeySocket.removeAllListeners).to.have.been.calledWith();
       expect(hokeySocket.close).to.have.been.calledWith();
       done();
@@ -163,7 +163,7 @@ describe('createSubject', () => {
     };
 
     const message = { content: { x: 2 } };
-    s.send(message);
+    s.next(message);
     expect(hokeySocket.send).to.have.been.calledWith(new jmp.Message(message));
 
     hokeySocket.emit('message', msg);


### PR DESCRIPTION
Real earnest conversion over to RxJS 5. The only thing that tripped me up was that `Subject.create` accepts `observable, subscriber` now instead of `Subject.create(observer, observable)`. Might add that in to the migration guide on RxJS 5.
