### PR TITLE
import needs to be capital Rx

### DIFF
--- a/src/subjection.js
+++ b/src/subjection.js
@@ -1,4 +1,4 @@
-import { Subscriber, Observable, Subject } from 'rxjs/rx';
+import { Subscriber, Observable, Subject } from 'rxjs/Rx';
 import * as jmp from 'jmp';
 
 import {


### PR DESCRIPTION
On OS X, this "wasn't" an issue because of case insensitivity of the file system.

Definitely needs fixing. Amusingly every other PR I did went about this properly.
