### PR TITLE
Use jmp-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
-    "jmp": "^0.4.0",
+    "@captainsafia/jmp-prebuilt": "^0.1.0",
     "rxjs": "^5.0.0-beta.6",
     "uuid": "^2.0.1"
   },

--- a/src/subjection.js
+++ b/src/subjection.js
@@ -1,5 +1,5 @@
 import { Subscriber, Observable, Subject } from 'rxjs/Rx';
-import * as jmp from 'jmp';
+import * as jmp from '@captainsafia/jmp-prebuilt';
 
 import {
   ZMQType,

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events';
 
 import * as constants from '../src/constants';
 
-import * as jmp from 'jmp';
+import * as jmp from '@captainsafia/jmp-prebuilt';
 
 import {
   deepFreeze,
@@ -96,6 +96,7 @@ describe('createObservable', () => {
         content: {
           success: true,
         },
+        signatureOK: true,
       });
       done();
     });
@@ -147,6 +148,7 @@ describe('createSubject', () => {
         content: {
           success: true,
         },
+        signatureOK: true,
       });
       s.complete();
       expect(hokeySocket.removeAllListeners).to.have.been.calledWith();


### PR DESCRIPTION
Using the `jmp-prebuilt` on my personal namespace for now. Can use official one once all work on `zmq-prebuilt` is done.
