### PR TITLE
Bump rxjs, jmp-prebuilt, eslint, and mocha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 sudo: false
 
 node_js: 
-  - "4.2"
   - "5.4"
 
 addons:
@@ -16,44 +15,8 @@ addons:
       - uuid-dev
       - wget
 
-env:
- - ZMQ="3.2.5"
- - ZMQ="4.0.5" SODIUM="1.0.5"
- - ZMQ="4.1.3" SODIUM="1.0.5"
-
 cache:
   apt: true
   directories:
     - node_modules
-    - zeromq-$ZMQ
 
-before_install:
- - export CXX=g++-4.8
- - export CC=gcc-4.8
- - mkdir ldlocal
- - export LDHACK=`pwd`/ldlocal
- - export LDFLAGS=-L$LDHACK/lib
- - export CFLAGS=-I$LDHACK/include
- - export LD_RUN_PATH=$LDHACK/lib
- - export LD_LIBRARY_PATH=$LDHACK/lib
- - export PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig
- - echo $PKG_CONFIG_PATH
- - wget http://download.zeromq.org/zeromq-$ZMQ.tar.gz
- - tar xzvf zeromq-$ZMQ.tar.gz
- - '[ -z "$SODIUM" ] || wget https://download.libsodium.org/libsodium/releases/libsodium-$SODIUM.tar.gz'
- - '[ -z "$SODIUM" ] || tar xzvf libsodium-$SODIUM.tar.gz'
- - '[ -z "$SODIUM" ] || cd libsodium-$SODIUM'
- - '[ -z "$SODIUM" ] || ./autogen.sh'
- - '[ -z "$SODIUM" ] || ./configure --prefix=$LDHACK'
- - '[ -z "$SODIUM" ] || make'
- - '[ -z "$SODIUM" ] || make install'
- - '[ -z "$SODIUM" ] || cd ..'
- - '[ -z "$SODIUM" ] || export LIBS=-lsodium && export sodium_CFLAGS=$CFLAGS && export sodium_LIBS=$LDFLAGS'
- - cd zeromq-$ZMQ
- - ./autogen.sh
- - if [[ -z "$SODIUM" ]]; then ./configure --prefix=$LDHACK; else ./configure --prefix=$LDHACK --with-libsodium=$LDHACK; fi
- - make
- - make install
- - cd ..
-
-install: env LD_LIBRARY_PATH=$LDHACK/lib LD_RUN_PATH=$LDHACK/lib PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig LDFLAGS=-L$LDHACK/lib CFLAGS=-I$LDHACK/lib/include npm install

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
-    "@captainsafia/jmp-prebuilt": "^0.1.1",
-    "rxjs": "^5.0.0-beta.6",
+    "@captainsafia/jmp-prebuilt": "^1.0.0",
+    "rxjs": "^5.0.0-beta.12",
     "uuid": "^2.0.1"
   },
   "babel": {
@@ -41,12 +41,12 @@
     "chai": "^3.4.1",
     "chai-immutable": "^1.5.3",
     "chalk": "^1.1.1",
-    "eslint": "^2.10.1",
+    "eslint": "^3.5.0",
     "eslint-plugin-babel": "^3.0.0",
     "fs-promise": "^0.5.0",
     "jupyter-paths": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.3.4",
+    "mocha": "^3.0.2",
     "portfinder": "^1.0.3",
     "rimraf": "^2.5.0",
     "sinon": "^1.17.2",


### PR DESCRIPTION
Time to raise our dependencies up, including the latest in RxJS technology.
