### PR TITLE
fix(buffers): Only freeze JSON parts of message

### DIFF
--- a/src/subjection.js
+++ b/src/subjection.js
@@ -71,8 +71,11 @@ export function createObservable(socket) {
                      // Conform to same message format as notebook websockets
                      // See https://github.com/n-riesco/jmp/issues/10
                      delete msg.idents;
-                     // Deep freeze the message
-                     deepFreeze(msg);
+                     // Deep freeze (most of) the message, not including buffers/blob
+                     msg.header && deepFreeze(msg.header);
+                     msg.parent_header && deepFreeze(msg.parent_header);
+                     msg.metadata && deepFreeze(msg.metadata);
+                     msg.content && deepFreeze(msg.content);
                      return msg;
                    })
                    .publish()

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -113,8 +113,10 @@ describe('createObservable', () => {
     const obs = createObservable(emitter);
 
     obs.subscribe(msg => {
-      expect(Object.isFrozen(msg)).to.be.true;
       expect(Object.isFrozen(msg.content)).to.be.true;
+      expect(Object.isFrozen(msg.metadata)).to.be.true;
+      expect(Object.isFrozen(msg.parent_header)).to.be.true;
+      expect(Object.isFrozen(msg.header)).to.be.true;
       done();
     });
     const msg = {


### PR DESCRIPTION
`blobs`/`buffers` can not be frozen because it's an Array Buffer View.

![screen shot 2016-09-23 at 8 25 27 pm](https://cloud.githubusercontent.com/assets/836375/18805938/09d5f5be-81d0-11e6-835b-82274da665b5.png)

This resorts to only freezing certain properties.
