### PR TITLE
Bump jmp, rxjs and remove unnecessary deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
-    "jmp-prebuilt": "^0.5.1",
-    "rxjs": "^5.0.0-beta.12",
+    "jmp": "^0.6.0",
+    "rxjs": "^5.0.0-rc.1",
     "uuid": "^2.0.1"
   },
   "babel": {
@@ -36,18 +36,13 @@
   "devDependencies": {
     "babel-cli": "^6.4.0",
     "babel-core": "^6.4.0",
-    "babel-eslint": "^6.0.4",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",
-    "chai-immutable": "^1.5.3",
     "chalk": "^1.1.1",
-    "eslint": "^3.5.0",
-    "eslint-plugin-babel": "^3.0.0",
     "fs-promise": "^0.5.0",
     "jupyter-paths": "^1.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.0.2",
-    "portfinder": "^1.0.3",
     "rimraf": "^2.5.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"

--- a/src/subjection.js
+++ b/src/subjection.js
@@ -1,5 +1,5 @@
 import { Subscriber, Observable, Subject } from 'rxjs/Rx';
-import * as jmp from 'jmp-prebuilt';
+import * as jmp from 'jmp';
 
 import {
   ZMQType,

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events';
 
 import * as constants from '../src/constants';
 
-import * as jmp from 'jmp-prebuilt';
+import * as jmp from 'jmp';
 
 import {
   deepFreeze,


### PR DESCRIPTION
`jmp` 0.6.0 uses `zmq-prebuilt` 🎉 
