### PR TITLE
Bump uuid and only require uuid/v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,28 @@
 [![GitHub release](https://img.shields.io/badge/enchannel--zmq--backend-version--latest-blue.svg)](https://github.com/nteract/enchannel-zmq-backend/releases)
 [![enchannel spec version](https://img.shields.io/badge/enchannel%20spec-version%201.1-ff69b4.svg)](https://github.com/nteract/enchannel/releases)
 
-[**Installation**](#installation) | [**Usage**](#usage) | 
-[**Contributors and developers**](#contributors-and-developers) | 
+[**Installation**](#installation) | [**Usage**](#usage) |
+[**Contributors and developers**](#contributors-and-developers) |
 [**Learn more about nteract**](#learn-more-about-nteract)
 
-**enchannel-zmq-backend** offers the ZeroMQ backend implementation for 
+**enchannel-zmq-backend** offers the ZeroMQ backend implementation for
 [`enchannel`](https://github.com/nteract/enchannel).
 
 ## Technical overview
 
 As a refresher for the reader, [*enchannel*][] details nteract's
 lightweight, implementation-flexible specification for communication
-between a user frontend and a backend, such as a language kernel. The 
-*enchannel* specification offers a simple description of "what" 
+between a user frontend and a backend, such as a language kernel. The
+*enchannel* specification offers a simple description of "what"
 messages may be passed between frontends and backends, while leaving
 a developer freedom in "how" to achieve message communication.
 
 **enchannel-zmq-backend** takes a classic design approach using ZeroMQ,
 the foundation messaging protocol for the Jupyter project.
 enchannel-zmq-backend implements backend support for the messaging
-channels described in the [Jupyter messaging specification][]. This 
-spec explains how front end clients should communicate with 
-backend language kernels which implement the Jupyter messaging 
+channels described in the [Jupyter messaging specification][]. This
+spec explains how front end clients should communicate with
+backend language kernels which implement the Jupyter messaging
 specification.
 
 ## Our backend
@@ -32,9 +32,9 @@ specification.
 **enchannel-zmq-backend** implements the "how" to communicate messages
 to and from a backend.
 
-We provide functions to create [RxJS](https://github.com/ReactiveX/RxJS) 
-[Subjects](http://reactivex.io/documentation/subject.html) (two way 
-[Observables](http://reactivex.io/documentation/observable.html) for 
+We provide functions to create [RxJS](https://github.com/ReactiveX/RxJS)
+[Subjects](http://reactivex.io/documentation/subject.html) (two way
+[Observables](http://reactivex.io/documentation/observable.html) for
 four of the channels described in the
 [Jupyter messaging specification][]:
 
@@ -62,20 +62,20 @@ To get access to all of the `channels` for messaging (`shell`, `control`,
 import { createChannels } from 'enchannel-zmq-backend'
 ```
 
-The `createChannels` function accepts two things: 
+The `createChannels` function accepts two things:
 
 - an identity
 
     You'll want to set up your identity, relying on the node `uuid` package:
-    
+
     ```javascript
-    const uuid = require('uuid');
-    const identity = uuid.v4();
+    const uuid = require('uuid/v4');
+    const identity = uuid();
     ```
 
 - a runtime object, such as a kernel (which matches the on-disk JSON).
   Using [`spawnteract`](https://github.com/nteract/spawnteract) with
-  this project helps streamline spawning a kernel. 
+  this project helps streamline spawning a kernel.
 
     ```javascript
     const runtimeConfig = {
@@ -98,7 +98,7 @@ const channels = createChannels(identity, runtimeConfig)
 const { shell, iopub, stdin, control } = channels;
 ```
 
-`enchannel-zmq-backend` also offers four convenience functions to 
+`enchannel-zmq-backend` also offers four convenience functions to
 easily create the messaging channels for `control`, `stdin`, `iopub`,
 and `shell` :
 
@@ -197,7 +197,7 @@ before you can send on a channel.
      payload: [] } }
 ```
 
-## Contributors and developers 
+## Contributors and developers
 
 ### ZeroMQ Dependency
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
-    "jmp": "^0.7.2",
+    "jmp": "^0.7.3",
     "rxjs": "^5.0.0-rc.2",
-    "uuid": "^2.0.1"
+    "uuid": "^3.0.1"
   },
   "babel": {
     "presets": [
@@ -40,7 +40,7 @@
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",
     "chalk": "^1.1.1",
-    "fs-promise": "^0.5.0",
+    "fs-promise": "^1.0.0",
     "jsdoc": "^3.4.0",
     "jupyter-paths": "^1.0.0",
     "mkdirp": "^0.5.1",

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -4,11 +4,11 @@
 const enchannelZMQ = require('../src');
 const createShellSubject = enchannelZMQ.createShellSubject;
 const createIOPubSubject = enchannelZMQ.createIOPubSubject;
-const uuid = require('uuid');
+const uuid = require('uuid/v4');
 const path = require('path');
 
 const chalk = require('chalk');
-const identity = uuid.v4();
+const identity = uuid();
 
 const fsp = require('fs-promise');
 const runtimeDir = require('jupyter-paths').runtimeDir();
@@ -36,7 +36,7 @@ fsp.readdir(runtimeDir)
 
     global.message = {
       header: {
-        msg_id: `execute_${uuid.v4()}`,
+        msg_id: `execute_${uuid()}`,
         username: '',
         session: '00000000-0000-0000-0000-000000000000',
         msg_type: 'execute_request',

--- a/test/channeling_spec.js
+++ b/test/channeling_spec.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */ // <-- Per Jupyter message spec
-import * as uuid from 'uuid';
+import v4 from 'uuid/v4';
 
 import { expect } from 'chai';
 
@@ -21,7 +21,7 @@ describe('createChannels', () => {
       control_port: 19011,
       iopub_port: 19012,
     };
-    const s = createChannels(uuid.v4(), config);
+    const s = createChannels(v4(), config);
 
     expect(s).to.be.an('object');
     expect(s.shell).to.be.an('object');
@@ -45,7 +45,7 @@ describe('createChannelSubject', () => {
       transport: 'tcp',
       iopub_port: 19009,
     };
-    const s = createChannelSubject('iopub', uuid.v4(), config);
+    const s = createChannelSubject('iopub', v4(), config);
     expect(s.next).to.be.a('function');
     expect(s.complete).to.be.a('function');
     expect(s.subscribe).to.be.a('function');
@@ -62,7 +62,7 @@ describe('createIOPubSubject', () => {
       transport: 'tcp',
       iopub_port: 19011,
     };
-    const s = createIOPubSubject(uuid.v4(), config);
+    const s = createIOPubSubject(v4(), config);
     s.complete();
   });
 });

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -6,7 +6,7 @@ const sinonChai = require('sinon-chai');
 const expect = chai.expect;
 chai.use(sinonChai);
 
-const uuid = require('uuid');
+const uuid = require('uuid/v4');
 
 import { EventEmitter } from 'events';
 
@@ -179,7 +179,7 @@ describe('createSocket', () => {
       transport: 'tcp',
       iopub_port: 9009,
     };
-    const identity = uuid.v4();
+    const identity = uuid();
 
     const socket = createSocket('iopub', identity, config);
     expect(socket).to.not.be.null;


### PR DESCRIPTION
This will make the version consistent with `jmp` and help with webpack in the future.