### PR TITLE
Refactor subjects

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,27 +1,28 @@
 /* eslint camelcase: 0 */
 //                   ^^---- for ignoring Jupyter JSON, like msg_id
 
-const enchannelZMQ = require('../src');
+const enchannelZMQ = require("../src");
 const createShellSubject = enchannelZMQ.createShellSubject;
 const createIOPubSubject = enchannelZMQ.createIOPubSubject;
-const uuidv4 = require('uuid/v4');
-const path = require('path');
+const uuidv4 = require("uuid/v4");
+const path = require("path");
 
-const chalk = require('chalk');
+const chalk = require("chalk");
 const identity = uuidv4();
 
-const fsp = require('fs-promise');
-const runtimeDir = require('jupyter-paths').runtimeDir();
+const fsp = require("fs-promise");
+const runtimeDir = require("jupyter-paths").runtimeDir();
 
-fsp.readdir(runtimeDir)
-   .then(data => {
-     const kernels = data.filter(x => (/kernel.+\.json/).test(x));
-     if(kernels.length <= 0) {
-       throw new Error('You need a running Jupyter session');
-     }
-     console.log('Using the first kernel!');
-     return path.join(runtimeDir, kernels[0]);
-   })
+fsp
+  .readdir(runtimeDir)
+  .then(data => {
+    const kernels = data.filter(x => /kernel.+\.json/.test(x));
+    if (kernels.length <= 0) {
+      throw new Error("You need a running Jupyter session");
+    }
+    console.log("Using the first kernel!");
+    return path.join(runtimeDir, kernels[0]);
+  })
   .then(runtimePath => {
     return fsp.readFile(runtimePath);
   })
@@ -37,25 +38,31 @@ fsp.readdir(runtimeDir)
     global.message = {
       header: {
         msg_id: `execute_${uuidv4()}`,
-        username: '',
-        session: '00000000-0000-0000-0000-000000000000',
-        msg_type: 'execute_request',
-        version: '5.0',
+        username: "",
+        session: "00000000-0000-0000-0000-000000000000",
+        msg_type: "execute_request",
+        version: "5.0"
       },
       content: {
         code: 'print("woo")',
         silent: false,
         store_history: true,
         user_expressions: {},
-        allow_stdin: false,
-      },
+        allow_stdin: false
+      }
     };
 
-    console.log(chalk.green('\nHINT: ') + chalk.white('iopub.subscribe(console.log, console.error)'));
-    console.log(chalk.green('\nHINT: ') + chalk.white('shell.subscribe(console.log, console.error)'));
-    console.log(chalk.green('\nHINT: ') + chalk.white('shell.send(message)'));
+    console.log(
+      chalk.green("\nHINT: ") +
+        chalk.white("iopub.subscribe(console.log, console.error)")
+    );
+    console.log(
+      chalk.green("\nHINT: ") +
+        chalk.white("shell.subscribe(console.log, console.error)")
+    );
+    console.log(chalk.green("\nHINT: ") + chalk.white("shell.send(message)"));
 
-    require('repl').start('> ');
+    require("repl").start("> ");
   })
   .catch(err => {
     console.error(err);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,16 +1,16 @@
-export const IOPUB = 'iopub';
-export const STDIN = 'stdin';
-export const SHELL = 'shell';
-export const CONTROL = 'control';
+export const IOPUB = "iopub";
+export const STDIN = "stdin";
+export const SHELL = "shell";
+export const CONTROL = "control";
 
-export const DEALER = 'dealer';
-export const SUB = 'sub';
+export const DEALER = "dealer";
+export const SUB = "sub";
 
 export const ZMQType = {
   frontend: {
     iopub: SUB,
     stdin: DEALER,
     shell: DEALER,
-    control: DEALER,
-  },
+    control: DEALER
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,6 @@
-import {
-  SHELL,
-  STDIN,
-  IOPUB,
-  CONTROL,
-} from './constants';
+import { SHELL, STDIN, IOPUB, CONTROL } from "./constants";
 
-import {
-  createSubject,
-  createSocket,
-} from './subjection';
+import { createSubject, createSocket } from "./subjection";
 
 /**
  * createChannels creates an enchannel spec channels object
@@ -21,13 +13,13 @@ import {
  * @param  {string} subscription            subscribed topic; defaults to all
  * @return {object} channels object, per enchannel spec
  */
-export function createChannels(identity, config, subscription='') {
+export function createChannels(identity, config, subscription = "") {
   return {
     shell: createShellSubject(identity, config),
     control: createControlSubject(identity, config),
     stdin: createStdinSubject(identity, config),
-    iopub: createIOPubSubject(identity, config, subscription),
-  }
+    iopub: createIOPubSubject(identity, config, subscription)
+  };
 }
 
 /**
@@ -108,7 +100,7 @@ export function createStdinSubject(identity, config) {
  * @return {Rx.Subject} subject for receiving messages on the shell_port
  *                      channel
  */
-export function createIOPubSubject(identity, config, subscription = '') {
+export function createIOPubSubject(identity, config, subscription = "") {
   const ioPubSocket = createSocket(IOPUB, identity, config);
   // ZMQ PUB/SUB subscription (not an Rx subscription)
   ioPubSocket.subscribe(subscription);

--- a/src/subjection.js
+++ b/src/subjection.js
@@ -48,15 +48,15 @@ export function formConnectionString(config, channel) {
  *                         and closes the underlying socket on complete()
  */
 export function createSubscriber(socket) {
-  return Subscriber.create(messageObject => {
-    socket.send(new jmp.Message(messageObject));
-  }, err => {
-    // We don't expect to send errors to the kernel
-    console.error(err);
-  }, () => {
-    // tear it down, tear it *all* down
-    socket.removeAllListeners();
-    socket.close();
+  return Subscriber.create({
+    next: messageObject => {
+      socket.send(new jmp.Message(messageObject));
+    },
+    complete: () => {
+      // tear it down, tear it *all* down
+      socket.removeAllListeners();
+      socket.close();
+    }
   });
 }
 

--- a/test/channeling_spec.js
+++ b/test/channeling_spec.js
@@ -1,33 +1,33 @@
 /* eslint camelcase: 0 */ // <-- Per Jupyter message spec
-import uuidv4 from 'uuid/v4';
+import uuidv4 from "uuid/v4";
 
-import { expect } from 'chai';
+import { expect } from "chai";
 
 import {
   createChannels,
   createChannelSubject,
-  createIOPubSubject,
-} from '../src';
+  createIOPubSubject
+} from "../src";
 
-describe('createChannels', () => {
-  it('creates the channels per enchannel spec', () => {
+describe("createChannels", () => {
+  it("creates the channels per enchannel spec", () => {
     const config = {
-      signature_scheme: 'hmac-sha256',
-      key: '5ca1ab1e-c0da-aced-cafe-c0ffeefacade',
-      ip: '127.0.0.1',
-      transport: 'tcp',
+      signature_scheme: "hmac-sha256",
+      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
+      ip: "127.0.0.1",
+      transport: "tcp",
       shell_port: 19009,
       stdin_port: 19010,
       control_port: 19011,
-      iopub_port: 19012,
+      iopub_port: 19012
     };
     const s = createChannels(uuidv4(), config);
 
-    expect(s).to.be.an('object');
-    expect(s.shell).to.be.an('object');
-    expect(s.stdin).to.be.an('object');
-    expect(s.control).to.be.an('object');
-    expect(s.iopub).to.be.an('object');
+    expect(s).to.be.an("object");
+    expect(s.shell).to.be.an("object");
+    expect(s.stdin).to.be.an("object");
+    expect(s.control).to.be.an("object");
+    expect(s.iopub).to.be.an("object");
 
     s.shell.complete();
     s.stdin.complete();
@@ -36,31 +36,31 @@ describe('createChannels', () => {
   });
 });
 
-describe('createChannelSubject', () => {
-  it('creates a subject for the channel', () => {
+describe("createChannelSubject", () => {
+  it("creates a subject for the channel", () => {
     const config = {
-      signature_scheme: 'hmac-sha256',
-      key: '5ca1ab1e-c0da-aced-cafe-c0ffeefacade',
-      ip: '127.0.0.1',
-      transport: 'tcp',
-      iopub_port: 19009,
+      signature_scheme: "hmac-sha256",
+      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
+      ip: "127.0.0.1",
+      transport: "tcp",
+      iopub_port: 19009
     };
-    const s = createChannelSubject('iopub', uuidv4(), config);
-    expect(s.next).to.be.a('function');
-    expect(s.complete).to.be.a('function');
-    expect(s.subscribe).to.be.a('function');
+    const s = createChannelSubject("iopub", uuidv4(), config);
+    expect(s.next).to.be.a("function");
+    expect(s.complete).to.be.a("function");
+    expect(s.subscribe).to.be.a("function");
     s.complete();
   });
 });
 
-describe('createIOPubSubject', () => {
-  it('creates a subject with the default iopub subscription', () => {
+describe("createIOPubSubject", () => {
+  it("creates a subject with the default iopub subscription", () => {
     const config = {
-      signature_scheme: 'hmac-sha256',
-      key: '5ca1ab1e-c0da-aced-cafe-c0ffeefacade',
-      ip: '127.0.0.1',
-      transport: 'tcp',
-      iopub_port: 19011,
+      signature_scheme: "hmac-sha256",
+      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
+      ip: "127.0.0.1",
+      transport: "tcp",
+      iopub_port: 19011
     };
     const s = createIOPubSubject(uuidv4(), config);
     s.complete();

--- a/test/constants_spec.js
+++ b/test/constants_spec.js
@@ -1,30 +1,27 @@
+import { expect } from "chai";
 
-import { expect } from 'chai';
-
-import * as constants from '../src/constants';
+import * as constants from "../src/constants";
 
 // Solely testing the exported interface
-describe('constants', () => {
-  it('exports the standard Jupyter channels', () => {
-    expect(constants.IOPUB).to.equal('iopub');
-    expect(constants.STDIN).to.equal('stdin');
-    expect(constants.SHELL).to.equal('shell');
-    expect(constants.CONTROL).to.equal('control');
+describe("constants", () => {
+  it("exports the standard Jupyter channels", () => {
+    expect(constants.IOPUB).to.equal("iopub");
+    expect(constants.STDIN).to.equal("stdin");
+    expect(constants.SHELL).to.equal("shell");
+    expect(constants.CONTROL).to.equal("control");
 
-    expect(constants.ZMQType.frontend[constants.IOPUB])
-      .to
-      .equal(constants.SUB);
+    expect(constants.ZMQType.frontend[constants.IOPUB]).to.equal(constants.SUB);
 
-    expect(constants.ZMQType.frontend[constants.STDIN])
-      .to
-      .equal(constants.DEALER);
+    expect(constants.ZMQType.frontend[constants.STDIN]).to.equal(
+      constants.DEALER
+    );
 
-    expect(constants.ZMQType.frontend[constants.SHELL])
-      .to
-      .equal(constants.DEALER);
+    expect(constants.ZMQType.frontend[constants.SHELL]).to.equal(
+      constants.DEALER
+    );
 
-    expect(constants.ZMQType.frontend[constants.CONTROL])
-      .to
-      .equal(constants.DEALER);
+    expect(constants.ZMQType.frontend[constants.CONTROL]).to.equal(
+      constants.DEALER
+    );
   });
 });

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -1,15 +1,15 @@
-import { expect } from 'chai';
+import { expect } from "chai";
 
 import {
   createControlSubject,
   createStdinSubject,
   createIOPubSubject,
-  createShellSubject,
-} from '..';
+  createShellSubject
+} from "..";
 
 // Solely testing the exported interface on the built ES5 JavaScript
-describe('the built version of enchannel-zmq-backend', () => {
-  it('exports create helpers for control, stdin, iopub, and shell', () => {
+describe("the built version of enchannel-zmq-backend", () => {
+  it("exports create helpers for control, stdin, iopub, and shell", () => {
     expect(createControlSubject).to.not.be.undefined;
     expect(createStdinSubject).to.not.be.undefined;
     expect(createIOPubSubject).to.not.be.undefined;

--- a/test/subjection_spec.js
+++ b/test/subjection_spec.js
@@ -1,52 +1,32 @@
 /* eslint camelcase: 0 */ // <-- Per Jupyter message spec
 
-const chai = require('chai');
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
 const expect = chai.expect;
 chai.use(sinonChai);
 
-const uuidv4 = require('uuid/v4');
+const uuidv4 = require("uuid/v4");
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from "events";
 
-import * as constants from '../src/constants';
+import * as constants from "../src/constants";
 
-import * as jmp from 'jmp';
+import * as jmp from "jmp";
 
 import {
-  deepFreeze,
   createSubscriber,
   createObservable,
   createSubject,
-  createSocket,
-} from '../src/subjection';
+  createSocket
+} from "../src/subjection";
 
-describe('deepFreeze', () => {
-  it('should Object.freeze nested objects', () => {
-    const obj = {
-      a: 1,
-      b: {
-        bb: {
-          c: 3,
-        },
-      },
-    };
-
-    deepFreeze(obj);
-
-    expect((() => {obj.a = 2;})).to.throw('Cannot assign to read only property');
-    expect((() => {obj.b.bb.c = 42;})).to.throw('Cannot assign to read only property');
-    expect((() => {obj.d = 12;})).to.throw('Can\'t add property d, object is not extensible');
-  });
-});
-
-describe('createSubscriber', () => {
-  it('creates a subscriber from a socket', () => {
+describe("createSubscriber", () => {
+  it("creates a subscriber from a socket", () => {
     const hokeySocket = {
       send: sinon.spy(),
       removeAllListeners: sinon.spy(),
-      close: sinon.spy(),
+      close: sinon.spy()
     };
 
     const ob = createSubscriber(hokeySocket);
@@ -54,11 +34,11 @@ describe('createSubscriber', () => {
     ob.next(message);
     expect(hokeySocket.send).to.have.been.calledWith(new jmp.Message(message));
   });
-  it('removes all listeners and closes the socket on complete()', () => {
+  it("removes all listeners and closes the socket on complete()", () => {
     const hokeySocket = {
       send: sinon.spy(),
       removeAllListeners: sinon.spy(),
-      close: sinon.spy(),
+      close: sinon.spy()
     };
 
     const ob = createSubscriber(hokeySocket);
@@ -66,11 +46,11 @@ describe('createSubscriber', () => {
     expect(hokeySocket.removeAllListeners).to.have.been.calledWith();
     expect(hokeySocket.close).to.have.been.calledWith();
   });
-  it('should only close once', () => {
+  it("should only close once", () => {
     const hokeySocket = {
       send: sinon.spy(),
       removeAllListeners: sinon.spy(),
-      close: sinon.spy(),
+      close: sinon.spy()
     };
 
     const ob = createSubscriber(hokeySocket);
@@ -86,52 +66,32 @@ describe('createSubscriber', () => {
   });
 });
 
-describe('createObservable', () => {
-  it('publishes clean enchannel messages', (done) => {
+describe("createObservable", () => {
+  it("publishes clean enchannel messages", done => {
     const emitter = new EventEmitter();
     const obs = createObservable(emitter);
 
     obs.subscribe(msg => {
       expect(msg).to.deep.equal({
         content: {
-          success: true,
+          success: true
         },
-        blobs: [],
+        blobs: []
       });
       done();
     });
     const msg = {
       blobs: [],
       content: {
-        success: true,
-      },
+        success: true
+      }
     };
-    emitter.emit('message', msg);
-  });
-  it('publishes deeply frozen objects', (done) => {
-    const emitter = new EventEmitter();
-    const obs = createObservable(emitter);
-
-    obs.subscribe(msg => {
-      expect(Object.isFrozen(msg.content)).to.be.true;
-      expect(Object.isFrozen(msg.metadata)).to.be.true;
-      expect(Object.isFrozen(msg.parent_header)).to.be.true;
-      expect(Object.isFrozen(msg.header)).to.be.true;
-      done();
-    });
-    const msg = {
-      idents: [],
-      blobs: [],
-      content: {
-        success: true,
-      },
-    };
-    emitter.emit('message', msg);
+    emitter.emit("message", msg);
   });
 });
 
-describe('createSubject', () => {
-  it('creates a subject that can send and receive', (done) => {
+describe("createSubject", () => {
+  it("creates a subject that can send and receive", done => {
     // This is largely captured above, we make sure that the subject gets
     // created properly
     const hokeySocket = new EventEmitter();
@@ -145,9 +105,9 @@ describe('createSubject', () => {
     s.subscribe(msg => {
       expect(msg).to.deep.equal({
         content: {
-          success: true,
+          success: true
         },
-        blobs: [],
+        blobs: []
       });
       s.complete();
       expect(hokeySocket.removeAllListeners).to.have.been.calledWith();
@@ -158,30 +118,30 @@ describe('createSubject', () => {
       idents: [],
       blobs: [],
       content: {
-        success: true,
-      },
+        success: true
+      }
     };
 
     const message = { content: { x: 2 } };
     s.next(message);
     expect(hokeySocket.send).to.have.been.calledWith(new jmp.Message(message));
 
-    hokeySocket.emit('message', msg);
+    hokeySocket.emit("message", msg);
   });
 });
 
-describe('createSocket', () => {
-  it('creates a JMP socket on the channel with identity', () => {
+describe("createSocket", () => {
+  it("creates a JMP socket on the channel with identity", () => {
     const config = {
-      signature_scheme: 'hmac-sha256',
-      key: '5ca1ab1e-c0da-aced-cafe-c0ffeefacade',
-      ip: '127.0.0.1',
-      transport: 'tcp',
-      iopub_port: 9009,
+      signature_scheme: "hmac-sha256",
+      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
+      ip: "127.0.0.1",
+      transport: "tcp",
+      iopub_port: 9009
     };
     const identity = uuidv4();
 
-    const socket = createSocket('iopub', identity, config);
+    const socket = createSocket("iopub", identity, config);
     expect(socket).to.not.be.null;
     expect(socket.identity).to.equal(identity);
     expect(socket.type).to.equal(constants.ZMQType.frontend.iopub);


### PR DESCRIPTION
By personal request by @williamstein, I've taken out the message freezing. A user can do this themselves by mapping over the stream if they really want the objects frozen.

One minor refactor of the subscriber creation to not squash errors from sockets (thanks @jayphelps).

While I was at it I ran prettier over the code base. 💅 