### PR TITLE
Travis: Use trusty image to support new requirements of zeromq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 sudo: false
+dist: trusty
 
 node_js:
   - "6"


### PR DESCRIPTION
The zeromq v4.3.0 requires newer build tooling on Linux

Closes #50 
Closes #51
Closes #52 
