### PR TITLE
trim down Rx bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
     "jmp": "^0.7.3",
-    "rxjs": "^5.4.0",
-    "uuid": "^3.0.1"
+    "rxjs": "^5.4.1",
+    "uuid": "^3.1.0"
   },
   "babel": {
     "presets": [

--- a/src/subjection.js
+++ b/src/subjection.js
@@ -1,4 +1,11 @@
-import { Subscriber, Observable, Subject } from "rxjs/Rx";
+import { Subscriber } from "rxjs/Subscriber";
+import { Observable } from "rxjs/Observable";
+import { Subject } from "rxjs/Subject";
+
+import "rxjs/add/observable/fromEvent";
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/publish";
+
 import * as jmp from "jmp";
 
 import { ZMQType } from "./constants";


### PR DESCRIPTION
Similar to https://github.com/nteract/nteract/pull/1780, this trims down the Rx bundle by only importing the used operators.